### PR TITLE
fixed syntax error thrown without backticks

### DIFF
--- a/src/main/java/org/anolis/databases/DatabaseHelper.java
+++ b/src/main/java/org/anolis/databases/DatabaseHelper.java
@@ -173,7 +173,7 @@ public class DatabaseHelper{
         }
         ContentValues data=new ContentValues();
         for(int i=0;i<columns.length;i++){
-            data.put(columns[i], values[i]);
+            data.put("`" + columns[i] + "`", values[i]);
         }
         return mDatabase.insert("`" + table + "`", null, data);
     }


### PR DESCRIPTION
I fixed a syntax error that was thrown without the backtick (`) operators around columns whenever multiple columns were passed into an insert query.
